### PR TITLE
feature: observations are also allowed

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,11 +93,7 @@ module.exports = function obj2Osm (opts) {
     })
 
     var attr = filterProps(row, WHITELISTS[row.type].attributes)
-    var nodeName = row.type
-    if (row.type === 'observation') {
-      nodeName = 'node'
-      children.push(h('tag', { k: '__mapeo_type', v: 'observation' }))
-    }
+    var nodeName = row.type === 'observation' ? 'node' : row.type
     next(null, h(nodeName, attr, children))
   }
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var WHITELISTS = {
   },
   changeset: {
     attributes: ['id', 'user', 'uid', 'created_at', 'closed_at', 'open',
-        'min_lat', 'min_lon', 'max_lat', 'max_lon', 'comments_count'],
+      'min_lat', 'min_lon', 'max_lat', 'max_lon', 'comments_count'],
     children: ['tag']
   },
   bounds: {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ var DEFAULT_MEMBER = {
 // Any node that is a child of a VALID_NODE that is not in `children` will throw an error
 var ELEMENT_ATTRIBUTES = ['id', 'user', 'uid', 'visible', 'version', 'changeset', 'timestamp', 'old_id', 'new_id', 'new_version']
 var WHITELISTS = {
+  observation: {
+    attributes: ELEMENT_ATTRIBUTES.concat(['lat', 'lon']),
+    children: ['tag']
+  },
   node: {
     attributes: ELEMENT_ATTRIBUTES.concat(['lat', 'lon']),
     children: ['tag']
@@ -89,7 +93,12 @@ module.exports = function obj2Osm (opts) {
     })
 
     var attr = filterProps(row, WHITELISTS[row.type].attributes)
-    next(null, h(row.type, attr, children))
+    var nodeName = row.type
+    if (row.type === 'observation') {
+      nodeName = 'node'
+      children.push(h('tag', { k: '__mapeo_type', v: 'observation' }))
+    }
+    next(null, h(nodeName, attr, children))
   }
 
   function end (next) {

--- a/lib/h.js
+++ b/lib/h.js
@@ -7,7 +7,7 @@ module.exports = function h (tag, attr, children) {
   if (!Array.isArray(children)) children = [children]
   if (!attr) attr = {}
 
-  var open = '<' + tag.replace(/[\/!]$/, '')
+  var open = '<' + tag.replace(/[/!]$/, '')
   var kattr = Object.keys(attr)
   if (kattr.length) {
     open += ' ' + kattr.map(function (k) {


### PR DESCRIPTION
Right now this module is filtering out all observations. This PR aims to fix that by allowing observations through and putting the appropriate metadata on them, so they can be converted back to observations when they are edited in OSM.
See companion PR: https://github.com/digidem/osm2obj/pull/10

It's unclear to me if this should be it's own module, since it will be adding extra mapeo-specific capacity.

There are no tests for this yet, either.